### PR TITLE
Fix potential issue with recordings

### DIFF
--- a/application/src/Entity/Meeting.php
+++ b/application/src/Entity/Meeting.php
@@ -452,9 +452,8 @@ class Meeting
     {
         if (!$this->recordings->contains($recording)) {
             $this->recordings[] = $recording;
-            $recording->setMeeting($this);
         }
-
+        $recording->setMeeting($this);
         return $this;
     }
 


### PR DESCRIPTION
* Autogenerated RecordingID can have the same ID as the ID is not
totally random
* Setting meeting ID only if the recording is not found in the list can
lead to a recording having no meeting set in addRecording