### PR TITLE
Switch base to an apache-based image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0
+FROM php:8.0-apache-bullseye
 
 LABEL maintainer="Andrew Lyons <andrew@nicols.co.uk>" \
     org.opencontainers.image.source="https://github.com/andrewnicols/bigbluebutton_mock"


### PR DESCRIPTION
For some reason there are a number of random fails with the CLI image on
various endpoints. Switching to the apache image seems to resolve these.

I'm running 100 repititions to confirm the fix now.