### PR TITLE
Add lock settings for Meetings

### DIFF
--- a/application/src/Entity/Meeting.php
+++ b/application/src/Entity/Meeting.php
@@ -51,6 +51,51 @@ class Meeting
     private $meetingName;
 
     /**
+     * @ORM\Column(type="boolean")
+     */
+    private $disableCam = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $disableMic = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $disablePrivateChat = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $disablePublicChat = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $disableNote= false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $lockedLayout = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $hideUserList = false;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $lockOnJoin = true;
+
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $lockOnJoinConfigurable = false;
+
+    /**
      * @ORM\Column(type="json")
      */
     private $metadata = [
@@ -477,7 +522,20 @@ class Meeting
     public function setServerID(string $serverID): self
     {
         $this->serverID = $serverID;
-
         return $this;
+    }
+
+    public function setLockSetting(string $lockName, bool $value) {
+        if (property_exists($this, $lockName)) {
+            $this->$lockName = $value;
+        }
+    }
+
+    public function getLockSetting(string $lockName): bool {
+        if (property_exists($this, $lockName)) {
+            // If lockOnJoin not set to true, this is false for every lock.
+            return $this->lockOnJoin && $this->$lockName;
+        }
+        return false;
     }
 }

--- a/application/templates/mocked_meeting.html.twig
+++ b/application/templates/mocked_meeting.html.twig
@@ -7,6 +7,11 @@
         <div data-identifier="meetingName">{{ meeting.meetingName }}</div>
         <div data-identifier="fullName">{{ attendee.fullName }}</div>
         <div data-identifier="attendeeRole">{{ attendee.role }}</div>
+        <ul data-identifier="lockSettings">
+            {% for key, value in lockSettings  %}
+                <li> {{ key }} : {{ value ? 'enabled':'disabled' }}</li>
+            {% endfor %}
+        </ul>
         <a href="{{ logoutURL }}">Leave Meeting</a>
         <a href="{{ logoutURL }}">End Meeting</a>
     </body>


### PR DESCRIPTION
The lock setting (see https://docs.bigbluebutton.org/dev/api.html#create) were not implemented and sent when creating a meeting.
- Set the values for each setting
- Display the settings status so we can use it in behat tests

