### PR TITLE
Add manual dispatch button and fix tags to be latest

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,6 +1,6 @@
 name: Docker multiarch publish
 
-on: push
+on: [push, workflow_dispatch]
 env:
   REPOSITORY: bigbluebutton_mock
 jobs:
@@ -36,7 +36,7 @@ jobs:
           images: |
             ${{ env.DOCKERHUB_OWNER }}/${{ env.REPOSITORY }}
           tags: |
-            type=raw,value={{branch}}
+            type=raw,value=latest
             type=ref,event=tag
       - name: Calculate image tag names for GCR
         if: env.GH_OWNER != ''


### PR DESCRIPTION
The dispatch button can be useful in some cases, to force a rebuild...

And the tags where being created with the branch name (main), when
what we want is the default "latest" one (and tags when there are
releases (that's correct).

In any case, this GHA is missing some little details like:

- Have a test phase to verify it works before building.
- Also run on PRs (not only on push).
- Only build the images when the repository is the moodlehq one.

That's not being fixed here, but surely should be considered.