### PR TITLE
Fix Recording ID generation to avoid collisions

### DIFF
--- a/application/src/Entity/Recording.php
+++ b/application/src/Entity/Recording.php
@@ -169,7 +169,7 @@ class Recording
         $this->recordID = sprintf(
             "%s-%s",
             md5($seed),
-            time() + rand(1, 100000)
+            time() + random_int(0, PHP_INT_MAX/2)
         );
     }
 


### PR DESCRIPTION
Attempt to fix MDL-73193 by generating more unique recordID. It seems that sometimes the identifier collides so using random_int and increasing the range will help.