### PR TITLE
The parameter 'guest' can be set to false 

### DIFF
--- a/application/src/Controller/ApiController.php
+++ b/application/src/Controller/ApiController.php
@@ -153,7 +153,7 @@ class ApiController extends DataController
 
         $attendee = new Attendee();
         $attendee->setServerID($serverID);
-        if ($request->query->has('guest')) {
+        if ($request->query->has('guest') && $request->query->get('guest') == 'true') {
             $attendee->setUserID('guest');
         } else {
             $attendee->setUserId($request->query->get('userID'));


### PR DESCRIPTION
The fact that the guest parameter is in the request is not a sufficient condition to know if we are in guest mode or not.
Consistent with the BigblueButton API.