### PR TITLE
Fix the disabledNote(s) field for previous releases of the plugin

### DIFF
--- a/application/src/Controller/ApiController.php
+++ b/application/src/Controller/ApiController.php
@@ -87,7 +87,8 @@ class ApiController extends DataController implements CheckSumController
         'disableMic',
         'disablePrivateChat',
         'disablePublicChat',
-        'disableNotes',
+        'disableNotes', // This is the real name of the setting (see MDL-82389).
+        'disableNote', // This was the previous name (a typo), but we need to keep it here for backward compatibility.
         'lockedLayout',
         'hideUserList',
         'lockOnJoin',

--- a/application/src/Entity/Meeting.php
+++ b/application/src/Entity/Meeting.php
@@ -619,12 +619,20 @@ class Meeting
         if (property_exists($this, $lockName)) {
             $this->$lockName = $value;
         }
+        // Keep the old behavior for disableNote.
+        if ($lockName === 'disableNote') {
+            $this->disableNotes = $value;
+        }
     }
 
     public function getLockSetting(string $lockName): bool {
         if (property_exists($this, $lockName)) {
             // If lockOnJoin not set to true, this is false for every lock.
             return $this->lockOnJoin && $this->$lockName;
+        }
+        // Keep the old behavior for disableNote.
+        if ($lockName === 'disableNote') {
+            return $this->disableNotes;
         }
         return false;
     }


### PR DESCRIPTION
* We need to now use disabledNotes but still allow for disabledNote field